### PR TITLE
Mkdocs compatible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing guide
+
+* All documentation files must be written in markdown format under the `docs` directory. File name should be suffixed with `.md`.
+* A basic markdown syntax can be found here: https://www.markdownguide.org/basic-syntax/
+
+## Docusaurus-MkDocs compatibility guide
+
+Please follow this compatibility guide to make sure the conversion from Docusaurus to MkDocs does not break. This guide is also following the best practice in Markdown formatting. Please maintain consistency in writing documentation.
+
+### Headings hierarchy
+
+- You must use heading 1 only once (# example title) at the beginning of an article, followed by heading 2 (## example title). Do not use heading 1 twice in an article. Only heading 2 and greater will be listed in the table of content of MkDocs on the right side of an article. Having two or more heading 1 in an article will result to table of content missing.
+
+### List/Numbering
+
+- You must give a blank line before a list/numbering/bullet point. Example:
+
+```
+This is my list:
+
+- point 1
+- point 2
+```
+
+Do NOT do this:
+
+```
+This is my list:
+- point 1
+- point 2
+```
+
+### Admonition
+
+- You must enclose your admonition with `:::` and `:::` on different lines. Example:
+
+```
+:::danger
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+```
+
+Do NOT do this:
+
+```
+:::danger Some **content** with _Markdown_ `syntax`. Check [this `api`](#). :::
+```
+
+
+### Relative path linking
+
+- Use relative linking with file name everywhere. This type of linking will also work in GitHub repository.
+
+Example:
+
+```
+For more info, see [Observability](../../Observability.md)
+```
+
+Do NOT use absolute path:
+
+```
+For more info, see [Observability](/docs/admin/Observability.md)
+```
+
+Do NOT use folder path:
+
+```
+For more info, see [Observability](/docs/admin/Observability)
+```
+
+Docusaurus also recommends using relative file paths instead. See https://docusaurus.io/docs/markdown-features/links .

--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 # Introduction
+
 This repository facilitates both the Administrator guide, and the User guide.
 The documentation can be rendered with either Docusaurus or mkdocs.
 
 An instantion of the docs is available here [https://severalnines.github.io/ccx-docs/](https://severalnines.github.io/ccx-docs/).
 
-# Setup
-## Docusaurus
+## Setup
+
+### Docusaurus
+
 1. Install node (e.g `brew install node`)
 2. `npm install`
 3. `yarn add @cmfcmf/docusaurus-search-local`
 3. `npm run build`
 4. `npm start` 
-## Mkdocs
-1. Install mkdocs (pip install mkdocs)
-2. Install material theme (pip install mkdocs-material)
-3. mkdocs server
 
-## Updating sidebar in mkdocs
-- Please update the sidebars.ts
-- You can now convert the sidebar.ts to mkdocs compatible nav structure:
+### MkDocs
+
+1. Install mkdocs (`pip install mkdocs mkdocs-material mkdocs-glightbox mkdocs-autorefs`)
+2. `mkdocs build`
+3. `mkdocs serve`
+
+### Updating sidebar in mkdocs
+
+- Please update the `sidebars.ts`
+- You can now convert the `sidebar.ts` to MkDocs compatible nav structure:
+
 ```
 node convert_sidebars.js
 python3 convert_sidebars.py > mkdocs-nav.yml
+python3 convert_admonitons.py
 ```
 
-# Website
+## Website
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
@@ -65,3 +73,8 @@ $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+
+## Contributing
+
+Please read the [Contributing guide](CONTRIBUTING.md).

--- a/docs/admin/Changelog.md
+++ b/docs/admin/Changelog.md
@@ -9,7 +9,7 @@ Downgrades are not supported.
 ::::
 
 :::info
-Please read this section [Upgrading the Control Plane](/docs/admin/Day2/Upgrading-the-Control-Plane) for more information how to upgrade.
+Please read this section [Upgrading the Control Plane](Day2/Upgrading-the-Control-Plane.md) for more information how to upgrade.
 ::::
 ## Release Notes - CCX - v1.50.9
 CMON version: 2.2.0-11542

--- a/docs/admin/Day2/Autoscaling.md
+++ b/docs/admin/Day2/Autoscaling.md
@@ -1,4 +1,5 @@
 # Autoscaling storage
+
 *Introduced in v.1.50.*
 
 CCX supports autoscaling of storage for datastores.
@@ -10,23 +11,24 @@ If enabled for a datastore, and the datastore has any node that exceeds a define
 
 This disk increase may be repeated multiple times if the disk usage continues to exceed the threshold after each increase.
 
-If the end-user has enabled notifications for a datastore then the designated email addresses will receive a notification when the datastore storage is scaled up. Email notifications is configured by the end-user under the [Datastore Settings](/docs/user/Howto/Datastore-settings#notifications-in-ccx).
+If the end-user has enabled notifications for a datastore then the designated email addresses will receive a notification when the datastore storage is scaled up. Email notifications is configured by the end-user under the [Datastore Settings](../../user/Howto/Datastore-settings#notifications-in-ccx).
 
 
 ## Configuration
 
 The threshold and percentage values are defined in helm values as `autoscaling.storage.threshold` and `autoscaling.storage.percentage`.
 
-The default `autoscaling.storage.threshold` is `70` and `autoscaling.storage.percentage` is `20`. 
+The default `autoscaling.storage.threshold` is `70` and `autoscaling.storage.percentage` is `20`.
 
 To disable storage autoscaling globally (users won't be able to enable it for their datastores) set `autoscaling.storage.enabled: false`
 
 ### End-user enablement
-The end user must enable the autoscale storage feature per datastore, see [Datastore Settings](/docs/user/Howto/Datastore-settings#auto-scaling-storage-size-in-ccx) for more information.
+
+The end user must enable the autoscale storage feature per datastore, see [Datastore Settings](../../user/Howto/Datastore-settings.md#auto-scaling-storage-size-in-ccx) for more information.
 
 ## Alarm notifications
-When the `autoscaling.storage.threshold` has been reached for a storage volume in a datastore, then AlertManager/VM_alert will raise an alert:
-called `HostAutoScaleDiskSpaceReached`. It may be look like this:
+
+When the `autoscaling.storage.threshold` has been reached for a storage volume in a datastore, then AlertManager/VM_alert will raise an alert called `HostAutoScaleDiskSpaceReached`. It may be look like this:
 
 ```
 #76390: [Prometheus]: [FIRING:1] HostAutoScaleDiskSpaceReached /dev/mapper/VG_data-data 1.2.3.4:9100 warning (<datastore uuid>>
@@ -36,4 +38,5 @@ Labels:
 - alertname = HostAutoScaleDiskSpaceReached
 - ClusterID = NNN
 ```
+
 If the end-user has not activated the autoscaling, then the alarm will be triggered repeatedly.

--- a/docs/admin/Day2/Autoscaling.md
+++ b/docs/admin/Day2/Autoscaling.md
@@ -11,7 +11,7 @@ If enabled for a datastore, and the datastore has any node that exceeds a define
 
 This disk increase may be repeated multiple times if the disk usage continues to exceed the threshold after each increase.
 
-If the end-user has enabled notifications for a datastore then the designated email addresses will receive a notification when the datastore storage is scaled up. Email notifications is configured by the end-user under the [Datastore Settings](../../user/Howto/Datastore-settings#notifications-in-ccx).
+If the end-user has enabled notifications for a datastore then the designated email addresses will receive a notification when the datastore storage is scaled up. Email notifications is configured by the end-user under the [Datastore Settings](../../user/Howto/Datastore-settings.md#notifications-in-ccx).
 
 
 ## Configuration

--- a/docs/admin/FAQ.md
+++ b/docs/admin/FAQ.md
@@ -11,7 +11,7 @@ Yes, the UI can be white-labeled.
 2022
 
 ### What database version does CCX support?
-Here is a list of [supported database versions](/docs/user/Reference/Supported-Databases).
+Here is a list of [supported database versions](../user/Reference/Supported-Databases.md).
 
 ### Do you support MongoDB?
 
@@ -23,7 +23,7 @@ Yes.
 
 ### What other clouds do you support?
 
-Please see the [features](/docs/user/) for information.
+Please see the [features](Index.md) for information.
 
 ### Are there any specific dependencies between CCX and OpenStack/VMware?
 

--- a/docs/admin/Index.md
+++ b/docs/admin/Index.md
@@ -13,11 +13,11 @@ Our deployment solutions offer customizable configurations for various node type
 
 We support integration with several leading Cloud Service Providers (CSPs), including:
 
-- [Amazon Web Services (AWS)](/admin/Installation/Cloud-Providers/aws.md)
-- [OpenStack](/admin/Installation/Cloud-Providers/openstack.md)
-- [CloudStack](/admin/Installation/Cloud-Providers/cloudstack.md)
-- [VMWare](/admin/Installation/Cloud-Providers/vmware.md)
-- [Google Cloud (GCP)](/admin/Installation/Cloud-Providers/gcp.md)
+- [Amazon Web Services (AWS)](Installation/Cloud-Providers/aws.md)
+- [OpenStack](Installation/Cloud-Providers/openstack.md)
+- [CloudStack](Installation/Cloud-Providers/cloudstack.md)
+- [VMWare](Installation/Cloud-Providers/vmware.md)
+- [Google Cloud (GCP)](Installation/Cloud-Providers/gcp.md)
 ### Database Support
 
 Our platform is compatible with a diverse array of database types, including:

--- a/docs/admin/Installation/CCX-Install-Laptop.md
+++ b/docs/admin/Installation/CCX-Install-Laptop.md
@@ -114,10 +114,10 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
 
 3. Deploy CCX:
 
-    :::danger
+:::danger
 
-    This setup is only for demo and development purposes and the installtion will only work for the specified CIDR or 0.0.0.0/0 if no CIDR is set. For production and testing we recommend [to follow the installation guide](Index.md) and overriding the values.yaml with your settings. If you set the CIDR below then CCX will only be able to access the datastores from this CIDR.
-    :::
+This setup is only for demo and development purposes and the installtion will only work for the specified CIDR or 0.0.0.0/0 if no CIDR is set. For production and testing we recommend [to follow the installation guide](Index.md) and overriding the values.yaml with your settings. If you set the CIDR below then CCX will only be able to access the datastores from this CIDR.
+:::
 
     **Using the CIDR 0.0.0.0/0 (access is allowed from everywhere, which might be a security risk):**
     
@@ -140,11 +140,10 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
       --set 'ccx.cidr=N.N.N.N/32'
     ```
 
-    :::note
+:::note
+If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
+:::
 
-    If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
-
-    :::
 ---
 
 ## Verification
@@ -174,16 +173,11 @@ The CC frontend is an administrative interface and allows the CCX administrator 
 
     ```bash
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-user}' | base64 -d
-    ```
-
-    ```bash
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-password}' | base64 -d
     ```
 
 :::danger
-
 Do not use this UI to delete clusters or add and remove nodes. Please see the [Troubleshooting guide](../Troubleshooting/Troubleshooting.md).
-
 :::
 
 ## Troubleshooting

--- a/docs/admin/Installation/CCX-Install-Laptop.md
+++ b/docs/admin/Installation/CCX-Install-Laptop.md
@@ -5,6 +5,7 @@ This guide explains how to install Docker Desktop, enable Kubernetes, configure 
 ---
 
 ## Prerequisites
+
 - **System requirements**: a laptop/desktop with atleast 4 cores and 8GB of RAM, 20GB of free storage.
 - **Docker Desktop**, you can download Docker Desktop from the [official Docker website](https://www.docker.com/products/docker-desktop/).
 - **kubectl** installed and on the PATH, [get kubectl here](https://kubernetes.io/docs/tasks/tools/#kubectl).
@@ -36,6 +37,7 @@ This guide explains how to install Docker Desktop, enable Kubernetes, configure 
     ```
 
 ---
+
 ## Step 2: Create and Switch to a Namespace
 
 1. Create a new namespace for CCX:
@@ -50,11 +52,11 @@ This guide explains how to install Docker Desktop, enable Kubernetes, configure 
     kubectl config set-context --current --namespace=ccx
     ```
 
+---
+
 ## Step 3: Configure AWS Credentials
 
 CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credentials need to be securely provided to Kubernetes as a secret.
-
-### Steps
 
 1. Run the following command to configure your AWS credentials:
 
@@ -104,21 +106,27 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
     ```
 
 2. Deploy CCXDEPS using the following command:
+    
     ```bash
     helm upgrade --install ccxdeps s9s/ccxdeps --debug --wait --set ingressController.enabled=true
     ```
+
 3. Deploy CCX:
+
     :::danger
-    This setup is only for demo and development purposes and the installtion will only work for the specified CIDR or 0.0.0.0/0 if no CIDR is set.
-    For production and testing we recommend [to follow the installation guide](/docs/admin/Installation) and overriding the values.yaml with your settings. If you set the CIDR below then CCX will only be able to access the datastores from this CIDR.
+    This setup is only for demo and development purposes and the installtion will only work for the specified CIDR or 0.0.0.0/0 if no CIDR is set. For production and testing we recommend [to follow the installation guide](Index.md) and overriding the values.yaml with your settings. If you set the CIDR below then CCX will only be able to access the datastores from this CIDR.
     :::
+
     **Using the CIDR 0.0.0.0/0 (access is allowed from everywhere, which might be a security risk):**
+    
     ```bash
     helm upgrade --install ccx s9s/ccx \
       --debug --wait \
       --set 'ccx.cloudSecrets[0]=aws'
     ```
+    
     **Using a custom CIDR N.N.N.N/32 (access is allowed only from *this* CIDR):**
+    
     ```bash
     curl ifconfig.me  
 
@@ -129,8 +137,9 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
       --set 'ccx.cloudSecrets[0]=aws' \
       --set 'ccx.cidr=N.N.N.N/32'
     ```
+    
     :::note
-    If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
+     If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
     :::
 ---
 
@@ -144,37 +153,47 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
     ```
 
 ## Accessing the frontends
+
 ### CCX frontend
+
 The CCX frontend is the end-user interface and allows the end-user to create and manage datastores. The necessary infrastructure (VMs, volumes, etc) are created and managed by CCX.
+
 1. Navigate to `https://ccx.localhost` in your web browser.
 2. Register a new user. In this configuration, no confirmation email will be sent and you will need to go back to `https://ccx.localhost` (you can press Back in the browser) and login with your email address and password.
 
 ### CC frontend
+
 The CC frontend is an administrative interface and allows the CCX administrator to manage datastores. 
+
 1. Navigate to `https://cc.localhost` in your web browser.
 2. Login with the CC credentials, which are stored in Kubernets secrets:
-```
+
+    ```
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-user}' | base64 -d
-```
-```    
+    ```
+    ```    
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-password}' | base64 -d
-```    
+    ```    
+
 :::danger
-Do not use this UI to delete clusters or add and remove nodes. Please see the [Troubleshooting guide](/docs/admin/Troubleshooting/).
+Do not use this UI to delete clusters or add and remove nodes. Please see the [Troubleshooting guide](../Troubleshooting/Troubleshooting.md).
 :::
 
 ## Troubleshooting
+
 - If you experience sudden glitches or pod failures, you can try allocate more resoures too Docker Desktop. You can allocated more resources under `Settings->Resources->Advanced`.
 - If you experience issues deploying, reset the environment (Settings->Kubernetes, Reset Kubernetes Cluster), increase resources, and try again.
-- [Troubleshooting guide](/docs/admin/Troubleshooting).
+- [Troubleshooting guide](../Troubleshooting/Troubleshooting.md).
 - Problems? [Create a GitHub issue](https://github.com/severalnines/ccx-docs/issues).
 
 ## Limitations
+
 - Backups are not supported. A license to CMON is required. Please contact [sales@severalnines.com](mailto:sales@severalnines.com).
 
 ## Next steps
-- [Installation guide](/docs/admin/Installation/).
+
+- [Installation guide](Index.md).
 ---
 
-This document provides step-by-step instructions to set up Docker Desktop, Kubernetes, and CCX with a datastore deployed in AWS. For further details, refer to the official [CCX documentation](https://severalnines.github.io/ccx-docs/).
+This document provides step-by-step instructions to set up Docker Desktop, Kubernetes, and CCX with a datastore deployed in AWS. For further details, refer to the official [CCX documentation](https://ccxdocs.severalnines.com/ccx-docs/).
 

--- a/docs/admin/Installation/CCX-Install-Laptop.md
+++ b/docs/admin/Installation/CCX-Install-Laptop.md
@@ -65,6 +65,7 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
     ```
 
     Provide the following details:
+
     - AWS Access Key ID
     - AWS Secret Access Key
     - Default Region
@@ -79,12 +80,12 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
     ```
     Verify the secret is available:
     ```
-        kubectl get secrets aws
+    kubectl get secrets aws
     ```
     The output of this command should look something like this:
     ```
-        NAME   TYPE     DATA   AGE
-        aws    Opaque   2      24s
+    NAME   TYPE     DATA   AGE
+    aws    Opaque   2      24s
     ```
 ---
 
@@ -114,6 +115,7 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
 3. Deploy CCX:
 
     :::danger
+
     This setup is only for demo and development purposes and the installtion will only work for the specified CIDR or 0.0.0.0/0 if no CIDR is set. For production and testing we recommend [to follow the installation guide](Index.md) and overriding the values.yaml with your settings. If you set the CIDR below then CCX will only be able to access the datastores from this CIDR.
     :::
 
@@ -137,9 +139,11 @@ CCX uses AWS credentials to deploy its datastore in the AWS cloud. These credent
       --set 'ccx.cloudSecrets[0]=aws' \
       --set 'ccx.cidr=N.N.N.N/32'
     ```
-    
+
     :::note
-     If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
+
+    If you move the laptop/computer where the installation is made to another location, then you must login to the AWS Console and add that network to the security group.
+
     :::
 ---
 
@@ -168,15 +172,18 @@ The CC frontend is an administrative interface and allows the CCX administrator 
 1. Navigate to `https://cc.localhost` in your web browser.
 2. Login with the CC credentials, which are stored in Kubernets secrets:
 
-    ```
+    ```bash
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-user}' | base64 -d
     ```
-    ```    
+
+    ```bash
     kubectl get secret cmon-credentials  -o jsonpath='{.data.cmon-password}' | base64 -d
-    ```    
+    ```
 
 :::danger
+
 Do not use this UI to delete clusters or add and remove nodes. Please see the [Troubleshooting guide](../Troubleshooting/Troubleshooting.md).
+
 :::
 
 ## Troubleshooting
@@ -195,5 +202,5 @@ Do not use this UI to delete clusters or add and remove nodes. Please see the [T
 - [Installation guide](Index.md).
 ---
 
-This document provides step-by-step instructions to set up Docker Desktop, Kubernetes, and CCX with a datastore deployed in AWS. For further details, refer to the official [CCX documentation](https://ccxdocs.severalnines.com/ccx-docs/).
+This document provides step-by-step instructions to set up Docker Desktop, Kubernetes, and CCX with a datastore deployed in AWS. For further details, refer to the official [CCX documentation](https://ccxdocs.severalnines.com/).
 

--- a/docs/admin/Installation/Index.md
+++ b/docs/admin/Installation/Index.md
@@ -11,7 +11,7 @@ For a more details please read the [architecture](architecture.md).
 
 ## Quickstart
 
-For laptop/desktop installation instructions please visit [Install CCX on a Laptop](/docs/admin/Installation/CCX-Install-Laptop).
+For laptop/desktop installation instructions please visit [Install CCX on a Laptop](CCX-Install-Laptop.md).
 
 ### Add Severalnines Helm Chart repository
 
@@ -159,7 +159,7 @@ Disk space can either be ephemeral or block storage. We recommend block storage 
 
 ### Cloud Provider Configuration
 
-To know more about the CCX Cloud Provider Configuration setup, please read [CCX Cloud Provider Configuration](Cloud-Providers.md).
+To know more about the CCX Cloud Provider Configuration setup, please read [CCX Cloud Provider Configuration](Cloud-Providers/Cloud-Providers.md).
 
 ### Production Environment Configs
 
@@ -183,7 +183,7 @@ Backups needs to be configured for:
 ### Observability
 
 - [Observability](Observability.md).
-- [Configuration Management](/admin/Day2/Config-Management.md)
-- [Lifecycle Management](/admin/Day2/Lifecycle-Management.md)
-- [Upgrading the Controlplane](/admin/Day2/Upgrading-the-Control-Plane.md)
+- [Configuration Management](../Day2/Config-Management.md)
+- [Lifecycle Management](../Day2/Lifecycle-Management.md)
+- [Upgrading the Controlplane](../Day2/Upgrading-the-Control-Plane.md)
 

--- a/docs/admin/Installation/Index.md
+++ b/docs/admin/Installation/Index.md
@@ -2,23 +2,25 @@
 
 CCX is a comprehensive data management and storage solution that offers a range of features including flexible node configurations, scalable storage options, secure networking, and robust observability tools. It supports various deployment types to cater to different scalability and redundancy needs, alongside comprehensive management functions for users, databases, nodes, and firewalls. The CCX project provides a versatile platform for efficient data handling, security, and operational management, making it suitable for a wide array of applications and workloads.
 
-# Architecture Overview Diagram 
+## Architecture Overview Diagram 
 
 
 ![CCX architecture](../images/ccx-architecture.png)
-For a more details please read the [architecture](/docs/admin/Installation/architecture).
 
-# Quickstart
+For a more details please read the [architecture](architecture.md).
+
+## Quickstart
 
 For laptop/desktop installation instructions please visit [Install CCX on a Laptop](/docs/admin/Installation/CCX-Install-Laptop).
 
-## Add Severalnines Helm Chart repository
+### Add Severalnines Helm Chart repository
+
 ```
 helm repo add s9s https://severalnines.github.io/helm-charts/
 helm repo update
 ```
 
-## Installation
+### Installation
 
 ```
 # Install CCX dependencies
@@ -38,9 +40,9 @@ helm install ccx s9s/ccx --debug --wait
 
 Please note that this will install CCX on `ccx.localhost`.
 
-## Configuring your CCX installation
+### Configuring your CCX installation
 
-### Providing cloud credentials
+#### Providing cloud credentials
 
 To be able to deploy datastores to a cloud provider (AWS by default) you need to provide cloud credentials.
 Cloud credentials should be created as kubernetes secrets in format specified in - https://github.com/severalnines/helm-charts/blob/main/charts/ccx/secrets-template.yaml
@@ -59,7 +61,7 @@ helm upgrade --install ccx s9s/ccx --debug --wait --set ccx.cloudSecrets[0]=aws
 ```
 
 
-### Setting up public access - custom domain name
+#### Setting up public access - custom domain name
 
 Make sure that you have ingress controller in your cluster and you are able to setup externally facing load balancers and that either your domain name points to the ingress IP or you have external DNS configured in your cluster.
 
@@ -70,13 +72,12 @@ Simply run:
 helm install ccx s9s/ccx --debug --wait --set ccxFQDN=ccx.example.com
 ```
 
-### Further config
+#### Further config
 
 Please have a look at the helm values and minimal recommended values for CCX
 
-https://github.com/severalnines/helm-charts/blob/main/charts/ccx/minimal-values.yaml
-
-https://github.com/severalnines/helm-charts/blob/main/charts/ccx/values.yaml
+- https://github.com/severalnines/helm-charts/blob/main/charts/ccx/minimal-values.yaml
+- https://github.com/severalnines/helm-charts/blob/main/charts/ccx/values.yaml
 
 
 
@@ -101,20 +102,24 @@ The control plane requires the following resources:
 
 CCX requires Kubernetes Cluster Version to be >=1.22.
 
-#### Namespace
+### Namespace
 
 A namespace must be configured for the CCX K8s services to operate.
 example: `ccx`
 
 ### Helm Charts
+
 The Helm charts are located in [https://artifacthub.io/packages/helm/severalnines/ccx](https://artifacthub.io/packages/helm/severalnines/ccx).
 The source respository is located in [https://github.com/severalnines/helm-charts](https://github.com/severalnines/helm-charts). The three charts used below are:
+
 - ccx
 - ccxdeps
 - observability
 
 ### Prerequisite tool sets for CCX Installation
+
 The following prerequisites are needed:
+
 - nginx ingress controller
 - NATS
 - external-dns (Please see - [DynamicDNS](Dynamic-DNS.md) and please check the supported DNS provider for external-dns [here](https://github.com/kubernetes-sigs/external-dns#status-of-providers)). If you do not find your DNS on this list, we recommend that you create a zone in e.g AWS Route 53, CloudFlare or Google Cloud DNS.
@@ -124,7 +129,8 @@ The following prerequisites are needed:
 
 This prequisite can be installed using ccxdeps. Dependencies required for CCX are created as child charts inside ccxdeps.
 By default only the ingress-nginx controller and the external-dns is not enabled in ccxdeps.
-you can enable by setting it to true by using below command.
+
+You can enable by setting it to true by using below command.
 
 ```
   helm repo add s9s https://severalnines.github.io/helm-charts/
@@ -132,27 +138,27 @@ you can enable by setting it to true by using below command.
   helm install ccxdeps s9s/ccxdeps --debug --set ingressController.enabled=true --set external-dns.enabled=true
 ```
 
-### Cloud Requirements
+## Cloud Requirements
 
-#### Flavors/images for datastores
+### Flavors/images for datastores
 
-CCX requires flavors built with Ubuntu 22.04 for the datastores.
-For a test/evaluation the following flavors are recommended:
+CCX requires flavors built with Ubuntu 22.04 for the datastores. For a test/evaluation the following flavors are recommended:
 
 - 2vCPU, 4GB RAM, 80GB Disk
 - 4vCPU, 8GB RAM, 100GB Disk
 
 Also, the easiest if there is a default login account called 'ubuntu' on the image.
 
-#### Floating IPs / Public IPs
+### Floating IPs / Public IPs
 
 Create a pool of floating IPs (public IPs). Each VM requires a floating IP/public IP.
 
-#### Disk Space
+### Disk Space
 
 Disk space can either be ephemeral or block storage. We recommend block storage as block storage devices can be scaled.
 
 ### Cloud Provider Configuration
+
 To know more about the CCX Cloud Provider Configuration setup, please read [CCX Cloud Provider Configuration](Cloud-Providers.md).
 
 ### Production Environment Configs
@@ -162,15 +168,19 @@ Backups needs to be configured for:
 - CMON database (See [mysql](Mysql-Operator-Installation.md))
 - CCX database (See [postgres](Postgres-Operator-Installation.md))
   
-:::note
-   Severalnines is not responsible for backups that is lost or incorrect configuration
-   #### Important Notice: Taking Persistent Volume Snapshots in Production Environment
+:::danger
+   Severalnines is not responsible for backups that is lost or incorrect configuration.
+:::
+
+:::danger
+   **Important Notice: Taking Persistent Volume Snapshots in Production Environment**
    To ensure data integrity and availability in your production environment, it is crucial to take regular snapshots of Persistent Volume Claims (PVCs) for CMON, DB's. Configure snapshot schedule at regular intervals, based on the criticality and update frequency of your data in your cloud environment
 :::
 
 
 ## Day 2:
-#### Observability
+
+### Observability
 
 - [Observability](Observability.md).
 - [Configuration Management](/admin/Day2/Config-Management.md)

--- a/docs/admin/Installation/architecture.md
+++ b/docs/admin/Installation/architecture.md
@@ -1,4 +1,5 @@
 # Architecture 
+
 This document describes the architecture of the controlplane.
 The CCX controlplane runs fully in Kubernetes and is comprised of a number of services.
 The services are responsible for authentication, state handling, monitoring, jobs handling etc. so that the lifecycle of a datastore can be maintained; from inception to destruction.
@@ -6,8 +7,11 @@ In this section we will cover the most core concepts in CCX.
 ![CCX architecture](../images/ccx-architecture.png)
 
 ## Controlplane
+
 This section describes the Controlplane, which runs in K8s.
+
 ### Jobs
+
 Actions taken on CCX is a handled as a job and is initiated by the end-user or the system automatically:
 
 - Deployment and destruction of a datastore
@@ -20,8 +24,10 @@ Actions taken on CCX is a handled as a job and is initiated by the end-user or t
 The jobs are managed by a service called `ccx-runner-service`
 
 ### Deployment 
+
 Deployment of a datastore is executed as a job. Moreover, one component called the CCX deployer is responsible for infrastructure creation and destruction.
 Creating a datastore involves the following steps:
+
 - create the VM
 - create network and attach to the VM.
 - allocate a public ip and and attach to the VM.
@@ -33,7 +39,9 @@ When the infrastructure has been created, then the VM boots and executes cloudin
 Cloudinit setups up SSL certificates and also installs the database software on the VM.
 
 ###  Controller (CMON) 
+
 Runs in a pod called `cmon-master`. 
+
 The controller is responsible for:
 
 - creating the datastore by setting up according to the configuration, e.g ensuring that replication links are created, backup schedules are configured.
@@ -46,82 +54,118 @@ The controller is responsible for:
 - provide details about query monitoring.
 
 ### Job Runner  
+
 The `ccx-runner-service` is responsible for jobs handling in CCX. Some jobs in CCX are mapped to a job executed by the Controller. Thus, if the job in the Controller fails, then the `ccx-runner-service` handles the failed job and takes further actions, e.g, to retry the job.
 
 ### Metadata repositories 
 
 #### CMON DB
+
 CMON DB is responsible for storing metadata required by the Controller (CMON). E.g, all the datastores (called `clusters` in CMON) are stored in this database. Also, jobs that CMON executes are stored here.
-CMON DB is managed by an operator in K8s, but it can be an externally managed database as well. Read more here about [installing the operator](/docs/admin/Installation/Mysql-Operator-Installation).
+
+CMON DB is managed by an operator in K8s, but it can be an externally managed database as well. Read more here about [installing the operator](Mysql-Operator-Installation.md).
 
 #### CCX DB
+
 CCX DB is responsible for storing metadata required by the CCX services. E.g users, infrastructure, and datastores.
-CCX DB is managed by an operator in K8s, but it can be an externally managed database as well. Read more here about [installing the operator](/docs/admin/Installation/Postgres-Operator-Installation).
+
+CCX DB is managed by an operator in K8s, but it can be an externally managed database as well. Read more here about [installing the operator](Postgres-Operator-Installation.md).
 
 ### Dependencies
 
 #### External DNS
+
 Each database node in a datastores has a FQDN. Also, there is an FQDN pointing to the primary writeable database node. This makes it easy for application developers as they only need to connect to a single endpoint; if the primary fails, then the DNS is updated to point to the new primary.
 
 Moreover, [ExternalDNS offers an interface to a number of DNS providers](https://github.com/kubernetes-sigs/external-dns?tab=readme-ov-file#the-latest-release). If you have a DNS provider that is not present in the list of DNS providers, then you need to create a zone in a supported DNS provider, e.g CloudFlare or Route53.
 
-Read more about [ExternalDNS](/docs/admin/Installation/Dynamic-DNS).
+Read more about [ExternalDNS](Dynamic-DNS.md).
 
-### Observability 
-CCX uses popular tools and techniques for observability. The tools are outlined below and more information can be found in the [installation guide](/docs/admin/Installation/Observability/).
+### Observability
+
+CCX uses popular tools and techniques for observability. The tools are outlined below and more information can be found in the [installation guide](Observability.md).
+
 #### VictoriaMetrics
+
 VictoriaMetrics is used to scrape exporters. Exporters are installed on all database. See below for more information.
 
 #### Loki
+
 Loki is used to store log files forwarded from the database VMs. See below for more information.
 
 #### Grafana
+
 Grafana is used for dashboards.
 
 ### Authentication, Frontends and API Access
+
 CCX services can be consumed using the CCX UI, a REST API or a Terraform Provider.
+
 #### Authentication
+
 Authentication to CCX is handled by the services `ccx-ui-auth` and `ccx-auth-service`.
 Authentication mechanism consists of:
+
 - Username / password
 - Oauth2 credentials (the CCX terraform provider uses this).
 - JWT - for UI and API integration.
+
 #### CCX UI
+
 The CCX UI can be customized and white-labeled. The CCX UI runs in a POD called `ccx-ui-app`.
+
 #### CCX Admin UI
+
 The CCX Admin UI provides basic administration features. It runs in a pod called `ccx-ui-admin`.
+
 #### REST API
+
 There is [Swagger](https://ccx.s9s-dev.net/api/docs/current/index.html) documentation describing the API.
+
 #### Terraform Provider
+
 Datastores can be created and scaled using the [Terraform provider](https://github.com/severalnines/terraform-provider-ccx). 
 
 ## Dataplane
+
 The dataplane is comprised of the cloud infrastructure. End-user resources are allocated on the dataplane.
 Each VM instance that is created will have:
+
 - storage, either ephemeral or block storage. Ephemeral storage cannot be scaled later. 
 - a network, a public IP so that the controlplane can access resources in the dataplane. There is also a private IP for internal node to node communication.
 The exact instance types, volume types, networks, depends from system to system and is setup by the CCX administrator and specified in values.yaml.
 
 ### Encryption
+
 Data is encrypted:
-- at rest (replication links, end-user connections, and other endpoints are TLS encrypted).
-- in-transit (LUKS is used).
+
+- in-transit (replication links, end-user connections, and other endpoints are TLS encrypted).
+- at-rest (LUKS is used).
 
 ### Cloud-init - VM boot 
+
 Cloud-init is executed during the firstboot of a VM. Cloud-init is responsible for:
+
 - installing certificates needed by the database node.
 - installing database software packages.
 
 ### Observability
+
 A few tools are installed on the database VMs to provide observability.
+
 #### Logging - LOKI and fluentbit
+
 Database logs are forwarded to Loki, which runs in the controlplane, using fluentbit. This is configured in the observability helm chart.
+
 #### Metrics
+
 Metris are sampled using exporters which are scraped by VictoriaMetrics. The following exporters are installed:
+
 - node_exporter
 - process_exporter, used by the CMON Controller, and provides information about running processes.
 - db_exporter, where db refers to the database specific type of exporter, e.g redis, mysql, postgres, etc.
 
 ### S3 Storage (object storage)
+
 An S3 compatible storage is required. If there is no existing S3 compatible storage, and Minio can be configured.
 The S3 storage stores backups.

--- a/docs/admin/Observability.md
+++ b/docs/admin/Observability.md
@@ -1,5 +1,5 @@
 # Observability
 For more information see:
-- [Observability](/admin/Installation/Observability.md)
-- [Logging](/admin/Installation/Logging.md)
-- [Email Notifications](/admin/Day2/Notifications.md)
+- [Observability](Installation/Observability.md)
+- [Logging](Installation/Logging.md)
+- [Email Notifications](Day2/Notifications.md)

--- a/docs/user/Howto/Config-management.md
+++ b/docs/user/Howto/Config-management.md
@@ -1,35 +1,45 @@
 # Database configuration in CCX
+
 :::note
 *Deprecated in v1.51 in favor of parameter groups* 
-Please see to [Parameter Groups](Parameter-group)
+Please see to [Parameter Groups](Parameter-group.md)
 ::: 
+
 In CCX, you have the ability to fine-tune your database performance by adjusting various **DB Parameters**. These parameters control the behavior of the database server and can impact performance, resource usage, and compatibility.
 
 ![img](../images/change_db_config.png)
 
 ## Available DB Parameters
+
 This is an example, and is subject to change and depends on the configuration of CCX.
+
 1. **group_concat_max_len**
+
    - **Description**: Specifies the maximum allowed result length of the `GROUP_CONCAT()` function.
    - **Max**: 104857600 | **Min**: 1024 | **Default**: 1024
 
 2. **interactive_timeout**
+
    - **Description**: Sets the number of seconds the server waits for activity on an interactive connection before closing it.
    - **Max**: 28800 | **Min**: 3000 | **Default**: 28800
 
 3. **max_allowed_packet**
+
    - **Description**: Specifies the maximum size of a packet or a generated/intermediate string.
    - **Max**: 1073741824 | **Min**: 536870912 | **Default**: 536870912
 
 4. **sql_mode**
+
    - **Description**: Defines the SQL mode for MySQL, which affects behaviors such as handling of invalid dates and zero values.
    - **Default**: `ONLY_FULL_GROUP_BY, STRICT_TRANS_TABLES, NO_ZERO_IN_DATE, NO_ZERO_DATE, ERROR_FOR_DIVISION_BY_ZERO, NO_ENGINE_SUBSTITUTION`
 
 5. **table_open_cache**
+
    - **Description**: Sets the number of open tables for all threads.
    - **Max**: 10000 | **Min**: 4000 | **Default**: 4000
 
 6. **wait_timeout**
+
    - **Description**: Defines the number of seconds the server waits for activity on a non-interactive connection before closing it.
    - **Max**: 28800 | **Min**: 3000 | **Default**: 28800
 

--- a/docs/user/Reference/Products/PostgreSQL/configuration.md
+++ b/docs/user/Reference/Products/PostgreSQL/configuration.md
@@ -15,7 +15,7 @@ These settings cannot be changed as it affects system stability
 
 ### Max connections
 The maximum number of connections depends on the instance size.
-The number of connections can be scaled by adding a new database secondary allowing of a larger instance size. The new replica can then be promoted to the new primary. See [Promoting a replica](/docs/user/Howto/Promote-a-replica) for more information.
+The number of connections can be scaled by adding a new database secondary allowing of a larger instance size. The new replica can then be promoted to the new primary. See [Promoting a replica](../../../Howto/Promote-a-replica.md) for more information.
 | Instance size (GiB RAM)       | Max connections |
 | ------------- |-------------|
 | < 4 | 100 |


### PR DESCRIPTION
Kindly accept this PR to make it compatible with MkDocs.  There is also CONTRIBUTING.md for the contributors to follow a certain formatting standard to ensure the markdown writings are compatible with Docusaurus and MkDocs. 

The auto-conversion to MkDocs is pushed to the staging environment: https://ccxdocsdev.severalnines.com/ .