### PR TITLE
JWT docs: recommend ccx.env, fix PKCS#1 vs PKIX example

### DIFF
--- a/docs/admin/Customisation/JWT.md
+++ b/docs/admin/Customisation/JWT.md
@@ -27,25 +27,28 @@ ssh-keygen -e -f ccx.key -m PEM > ccx.key.pub
 
 #### Public key configuration in CCX Helm values:
 
-You need to set the configuration parameters in `ccx.services.auth` in ccx values.yaml
+Both `ccx-auth-service` (which validates the JWT) and `ccx-user` (which creates or updates the user) read `JWT_PUBLIC_KEY_ID` and `JWT_PUBLIC_KEY_PEM`. The simplest way to set them is under the top-level `ccx.env` in your values file — that block becomes a shared ConfigMap that is `envFrom`'d into every CCX service:
 
+```yaml
+ccx:
+  env:
+    JWT_PUBLIC_KEY_ID: 'MYCLOUD'
+    JWT_PUBLIC_KEY_PEM: |-
+        -----BEGIN RSA PUBLIC KEY-----
+        MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxowkw7Zf2pXoehn2CkwQ
+        sHqbASdRp2DENgUEIGj+iqQPMDZor2CD1fVYpVZW+kcQkR9SgIvb+QiSgdHvWegs
+        -----END RSA PUBLIC KEY-----
 ```
-      env:
-        JWT_PUBLIC_KEY_ID: 'MYCLOUD'
-        JWT_PUBLIC_KEY_PEM: |-
-            -----BEGIN PUBLIC KEY-----
-            MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxowkw7Zf2pXoehn2CkwQ
-            sHqbASdRp2DENgUEIGj+iqQPMDZor2CD1fVYpVZW+kcQkR9SgIvb+QiSgdHvWegs
-            -----END PUBLIC KEY-----
-```
+
+The `ssh-keygen -e -m PEM` command above produces a PKCS#1 key (`-----BEGIN RSA PUBLIC KEY-----`), which is the default format CCX expects. If you instead supply a PKIX-encoded key (`-----BEGIN PUBLIC KEY-----`, e.g. from `openssl rsa -pubout`), also set `JWT_PUBLIC_KEY_PKIX: "1"`.
 
 #### JWT Environment Variables
 
-| Environment Variable    | Description                                               |
-| ----------------------- | --------------------------------------------------------- |
-| **JWT_PUBLIC_KEY_ID**   | The identifier of the provider, e.g., "MYCLOUD".      |
-| **JWT_PUBLIC_KEY_PEM**  | The public key in PEM format (contents of `ccx.key.pub`). |
-| **JWT_PUBLIC_KEY_PKIX** | Should be "1" if the key is in PKIX format (optional).    |
+| Environment Variable    | Description                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **JWT_PUBLIC_KEY_ID**   | The identifier of the provider, e.g., "MYCLOUD".                                                            |
+| **JWT_PUBLIC_KEY_PEM**  | The public key in PEM format (contents of `ccx.key.pub`).                                                   |
+| **JWT_PUBLIC_KEY_PKIX** | Set to "1" if the key is in PKIX format (`-----BEGIN PUBLIC KEY-----`); leave unset for PKCS#1 (the default from `ssh-keygen -e -m PEM`). |
 
 ---
 

--- a/docs/admin/Customisation/JWT.md
+++ b/docs/admin/Customisation/JWT.md
@@ -35,8 +35,7 @@ ccx:
     JWT_PUBLIC_KEY_ID: 'MYCLOUD'
     JWT_PUBLIC_KEY_PEM: |-
         -----BEGIN RSA PUBLIC KEY-----
-        MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxowkw7Zf2pXoehn2CkwQ
-        sHqbASdRp2DENgUEIGj+iqQPMDZor2CD1fVYpVZW+kcQkR9SgIvb+QiSgdHvWegs
+        <paste the contents of ccx.key.pub here>
         -----END RSA PUBLIC KEY-----
 ```
 


### PR DESCRIPTION
## Summary
- `JWT_PUBLIC_KEY_ID` and `JWT_PUBLIC_KEY_PEM` are consumed by both `ccx-auth-service` and `ccx-user`, not just auth. Recommend putting them under the global `ccx.env` (which becomes a shared ConfigMap that is \`envFrom\`'d into every CCX service) instead of `ccx.services.auth.env`.
- The example key was PKIX (\`-----BEGIN PUBLIC KEY-----\`) but the \`ssh-keygen -e -m PEM\` command shown immediately above produces PKCS#1 (\`-----BEGIN RSA PUBLIC KEY-----\`). Switched the example to PKCS#1 and clarified that \`JWT_PUBLIC_KEY_PKIX=1\` is only needed if you supply a PKIX-encoded key.

## Test plan
- [x] Followed the updated instructions against a local CCX install — JWT login round-trip via [ccx-jwt-sample](https://github.com/severalnines/ccx-jwt-sample) works end-to-end.

Generated with [Claude Code](https://claude.com/claude-code)