### PR TITLE
Unify ccxdeps helm repo and values file naming across docs

### DIFF
--- a/docs/admin/Day2/Upgrading-to-be-production-ready.md
+++ b/docs/admin/Day2/Upgrading-to-be-production-ready.md
@@ -37,7 +37,7 @@ stringData:
     aws_secret_access_key = 
 ```
 
-Originally the `ccxdeps` helm chart was installed in tutorial using the default values. Create a new file called `ccxdeps.yaml`. You can use the values below and modify them per your needs.
+Originally the `ccxdeps` helm chart was installed in tutorial using the default values. Create a new file called `ccxdeps-values.yaml`. You can use the values below and modify them per your needs.
 
 ```
 keycloak:
@@ -178,7 +178,7 @@ Please take a look at all [values](https://github.com/severalnines/helm-charts/b
 
 To upgrade the chart, use the following command:
 ```
-helm upgrade --install ccxdeps s9s/ccxdeps --debug --wait -n ccx -f ccxdeps.yaml
+helm upgrade --install ccxdeps s9s/ccxdeps --debug --wait -n ccx -f ccxdeps-values.yaml
 ```
 
 :::note

--- a/docs/admin/Installation/Mysql-Operator-Installation.md
+++ b/docs/admin/Installation/Mysql-Operator-Installation.md
@@ -102,7 +102,7 @@ It is recommended to have backup enabled so that it can be restored on cluster f
 Once the `ccxdeps-values.yaml` is ready, then run:
 
 ```bash
-helm install ccxdeps ccxdeps/ccxdeps --debug -f ccxdeps-values.yaml
+helm install ccxdeps s9s/ccxdeps --debug -f ccxdeps-values.yaml
 ```
 
 You should see running Pods such as one MySQL router instance, MySQL Operator and MySQL servers.

--- a/docs/admin/Installation/Postgres-Operator-Installation.md
+++ b/docs/admin/Installation/Postgres-Operator-Installation.md
@@ -74,7 +74,7 @@ postgresql:
 Once configured and `ccxdeps-values.yaml` is ready, then run the command:
 
 ```bash
-helm upgrade --install ccxdeps ccxdeps/ccxdeps --debug -f ccxdeps-values.yaml
+helm upgrade --install ccxdeps s9s/ccxdeps --debug -f ccxdeps-values.yaml
 ```
 
 ### Restoring a backup for recovery
@@ -104,7 +104,7 @@ postgresql:
 Once configured, upgrade it to use values:
 
 ```bash
-helm upgrade --install ccxdeps ccxdeps/ccxdeps --debug -f ccxdeps-values.yaml
+helm upgrade --install ccxdeps s9s/ccxdeps --debug -f ccxdeps-values.yaml
 ```
 
 ### Postgres cluster options

--- a/docs/admin/Installation/Production-Openshift-installation.md
+++ b/docs/admin/Installation/Production-Openshift-installation.md
@@ -274,7 +274,7 @@ First, we need to install the CCX dependencies (`ccxdeps`):
 
 ### Installing the Dependencies
 
-Create a new file called `ccxdeps.yaml`. You can use the values below and modify them per your needs.
+Create a new file called `ccxdeps-values.yaml`. You can use the values below and modify them per your needs.
 ```
 mysql-innodbcluster:
   serverInstances: 3 # This is something you can chose, but it can only be 1,3,5,7 or 9.
@@ -313,7 +313,7 @@ installOperators: true
 Please take a look at all [values](https://github.com/severalnines/helm-charts/blob/main/charts/ccxdeps/values.yaml), as you might be interested in some of the additional flags.
 
 ```
-helm install ccxdeps s9s/ccxdeps --debug --wait -n ccx -f ccxdeps.yaml
+helm install ccxdeps s9s/ccxdeps --debug --wait -n ccx -f ccxdeps-values.yaml
 ```
 
 Check that the pods are `RUNNING`:


### PR DESCRIPTION
## Summary

- Replace `ccxdeps/ccxdeps` with `s9s/ccxdeps` in the Postgres and MySQL operator installation pages — the docs only ever add the helm repo under the name `s9s` (`helm repo add s9s https://severalnines.github.io/helm-charts/`), so the `ccxdeps` repo alias was never defined.
- Rename the values file from `ccxdeps.yaml` to `ccxdeps-values.yaml` in the production-readiness upgrade guide and the Production OpenShift installation guide, matching the rest of the docs (data backups, control-plane upgrade guide, operator pages, JWT/iframe section).

`ccxdeps.yaml` mentions in Deploying-with-ArgoCD.md are left untouched on purpose: there it is a file inside the ArgoCD git repository referenced by path in the `ApplicationSet` definitions, not a `helm -f` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)